### PR TITLE
feat: add PWA support with manifest, service worker, and install UI

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,8 +1,12 @@
 import './styles/app.css';
 import './stimulus_bootstrap.js';
-/*
- * Welcome to your app's main JavaScript file!
- *
- * This file will be included onto the page via the importmap() Twig function,
- * which should already be in your base.html.twig.
- */
+
+// Register Service Worker for PWA support
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js', { scope: '/' })
+            .catch(() => {
+                // Service worker registration failed — app still works normally
+            });
+    });
+}

--- a/assets/controllers/pwa_controller.js
+++ b/assets/controllers/pwa_controller.js
@@ -1,0 +1,72 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * PWA controller — handles install prompt and online/offline status.
+ */
+export default class extends Controller {
+    static targets = ['installBtn', 'offlineBanner'];
+
+    connect() {
+        this._deferredPrompt = null;
+        this._bindInstallPrompt();
+        this._bindNetworkStatus();
+    }
+
+    disconnect() {
+        window.removeEventListener('beforeinstallprompt', this._onBeforeInstallPrompt);
+        window.removeEventListener('online', this._onOnline);
+        window.removeEventListener('offline', this._onOffline);
+    }
+
+    // ─── Install ────────────────────────────────────────────────────────────
+
+    _bindInstallPrompt() {
+        this._onBeforeInstallPrompt = (event) => {
+            event.preventDefault();
+            this._deferredPrompt = event;
+            if (this.hasInstallBtnTarget) {
+                this.installBtnTarget.hidden = false;
+            }
+        };
+
+        window.addEventListener('beforeinstallprompt', this._onBeforeInstallPrompt);
+
+        window.addEventListener('appinstalled', () => {
+            this._deferredPrompt = null;
+            if (this.hasInstallBtnTarget) {
+                this.installBtnTarget.hidden = true;
+            }
+        });
+    }
+
+    async install() {
+        if (!this._deferredPrompt) return;
+        this._deferredPrompt.prompt();
+        await this._deferredPrompt.userChoice;
+        this._deferredPrompt = null;
+        if (this.hasInstallBtnTarget) {
+            this.installBtnTarget.hidden = true;
+        }
+    }
+
+    // ─── Online / Offline ────────────────────────────────────────────────────
+
+    _bindNetworkStatus() {
+        this._onOnline = () => this._setOffline(false);
+        this._onOffline = () => this._setOffline(true);
+
+        window.addEventListener('online', this._onOnline);
+        window.addEventListener('offline', this._onOffline);
+
+        // Set initial state
+        if (!navigator.onLine) {
+            this._setOffline(true);
+        }
+    }
+
+    _setOffline(isOffline) {
+        if (this.hasOfflineBannerTarget) {
+            this.offlineBannerTarget.hidden = !isOffline;
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -383,3 +383,51 @@ html.no-transition *::after {
         font-size: 0.85rem;
     }
 }
+
+/* ===========================
+   PWA — Offline Banner & Install
+   =========================== */
+
+.offline-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    padding: 10px 16px;
+    background: rgba(248, 113, 113, 0.15);
+    border-bottom: 1px solid rgba(248, 113, 113, 0.4);
+    color: var(--color-error);
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+    backdrop-filter: blur(8px);
+    letter-spacing: 0.02em;
+}
+
+.pwa-install-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 22px;
+    margin: 0 auto 20px;
+    background: var(--color-gold-btn-bg);
+    border: 1px solid var(--color-gold-border-btn);
+    border-radius: 30px;
+    color: var(--color-gold);
+    font-family: var(--font-serif);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--transition-fast), box-shadow var(--transition-fast);
+    letter-spacing: 0.03em;
+}
+
+.pwa-install-btn:hover {
+    background: var(--color-gold-btn-hover);
+    box-shadow: 0 0 12px var(--color-gold-glow);
+}
+
+.pwa-install-btn[hidden] {
+    display: none;
+}

--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="50%" style="stop-color:#16213e"/>
+      <stop offset="100%" style="stop-color:#0f3460"/>
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="32" fill="url(#bg)"/>
+  <rect width="192" height="192" rx="32" fill="none" stroke="#f5c842" stroke-width="4" stroke-opacity="0.5"/>
+  <text x="96" y="128" font-size="96" text-anchor="middle" font-family="Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif">🐶</text>
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="50%" style="stop-color:#16213e"/>
+      <stop offset="100%" style="stop-color:#0f3460"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="80" fill="url(#bg)"/>
+  <rect width="512" height="512" rx="80" fill="none" stroke="#f5c842" stroke-width="8" stroke-opacity="0.5"/>
+  <text x="256" y="336" font-size="256" text-anchor="middle" font-family="Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif">🐶</text>
+  <text x="256" y="460" font-size="44" text-anchor="middle" font-weight="bold" fill="#f5c842" font-family="Georgia, serif" letter-spacing="2">FoolDog</text>
+</svg>

--- a/public/icons/icon-maskable-512.svg
+++ b/public/icons/icon-maskable-512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="50%" style="stop-color:#16213e"/>
+      <stop offset="100%" style="stop-color:#0f3460"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#bg)"/>
+  <text x="256" y="310" font-size="220" text-anchor="middle" font-family="Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif">🐶</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,48 @@
+{
+    "name": "FoolDog - Lëtzebuergesche Witzhünn",
+    "short_name": "FoolDog",
+    "description": "Lëtzebuergesch Witze mat Ärem léifsten Witzhünn",
+    "start_url": "/",
+    "display": "standalone",
+    "orientation": "portrait-primary",
+    "background_color": "#1a1a2e",
+    "theme_color": "#1a1a2e",
+    "lang": "lb",
+    "categories": ["entertainment"],
+    "icons": [
+        {
+            "src": "/icons/icon-192.svg",
+            "sizes": "192x192",
+            "type": "image/svg+xml",
+            "purpose": "any"
+        },
+        {
+            "src": "/icons/icon-512.svg",
+            "sizes": "512x512",
+            "type": "image/svg+xml",
+            "purpose": "any"
+        },
+        {
+            "src": "/icons/icon-maskable-512.svg",
+            "sizes": "512x512",
+            "type": "image/svg+xml",
+            "purpose": "maskable"
+        }
+    ],
+    "screenshots": [],
+    "shortcuts": [
+        {
+            "name": "Zufälleg Witz",
+            "short_name": "Witz",
+            "description": "Kritt e zufälleg Witz",
+            "url": "/",
+            "icons": [
+                {
+                    "src": "/icons/icon-192.svg",
+                    "sizes": "192x192",
+                    "type": "image/svg+xml"
+                }
+            ]
+        }
+    ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,137 @@
+/**
+ * FoolDog Service Worker
+ * Provides offline support and asset caching for the PWA.
+ */
+
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `fooldog-static-${CACHE_VERSION}`;
+const API_CACHE = `fooldog-api-${CACHE_VERSION}`;
+const PAGE_CACHE = `fooldog-pages-${CACHE_VERSION}`;
+
+const STATIC_ASSETS_PATTERN = /\/build\//;
+const API_PATTERN = /\/api\//;
+const ICON_PATTERN = /\/icons\//;
+
+// Offline fallback for when a joke fetch fails
+const OFFLINE_JOKES = [
+    {
+        id: 0,
+        content: 'Firwat kann den Hond keen Computer benotzen? Well hien Angst virum Cat-scan huet! 🐾',
+        emoji: '🐶',
+        author: 'FoolDog Offline',
+        createdAt: null
+    }
+];
+
+// ─── Install ──────────────────────────────────────────────────────────────────
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(PAGE_CACHE).then((cache) =>
+            cache.addAll(['/'])
+        ).then(() => self.skipWaiting())
+    );
+});
+
+// ─── Activate ─────────────────────────────────────────────────────────────────
+
+self.addEventListener('activate', (event) => {
+    const allowedCaches = [STATIC_CACHE, API_CACHE, PAGE_CACHE];
+    event.waitUntil(
+        caches.keys().then((keys) =>
+            Promise.all(
+                keys
+                    .filter((key) => !allowedCaches.includes(key))
+                    .map((key) => caches.delete(key))
+            )
+        ).then(() => self.clients.claim())
+    );
+});
+
+// ─── Fetch ────────────────────────────────────────────────────────────────────
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+    const url = new URL(request.url);
+
+    // Only handle same-origin requests
+    if (url.origin !== self.location.origin) return;
+
+    // Static assets (Webpack build artefacts) — cache-first
+    if (STATIC_ASSETS_PATTERN.test(url.pathname) || ICON_PATTERN.test(url.pathname)) {
+        event.respondWith(cacheFirst(request, STATIC_CACHE));
+        return;
+    }
+
+    // API calls — network-first, fall back to cache, then offline stub
+    if (API_PATTERN.test(url.pathname)) {
+        event.respondWith(networkFirstApi(request));
+        return;
+    }
+
+    // HTML pages — network-first, fall back to cached page
+    if (request.headers.get('accept')?.includes('text/html')) {
+        event.respondWith(networkFirstPage(request));
+        return;
+    }
+});
+
+// ─── Strategies ───────────────────────────────────────────────────────────────
+
+async function cacheFirst(request, cacheName) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+
+    const response = await fetch(request);
+    if (response.ok) {
+        const cache = await caches.open(cacheName);
+        cache.put(request, response.clone());
+    }
+    return response;
+}
+
+async function networkFirstApi(request) {
+    const cache = await caches.open(API_CACHE);
+
+    try {
+        const response = await fetch(request);
+        if (response.ok) {
+            cache.put(request, response.clone());
+        }
+        return response;
+    } catch {
+        const cached = await cache.match(request);
+        if (cached) return cached;
+
+        // Return offline stub for /api/jokes
+        if (request.url.includes('/api/jokes')) {
+            return new Response(JSON.stringify(OFFLINE_JOKES), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        return new Response(JSON.stringify({ error: 'Offline' }), {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+}
+
+async function networkFirstPage(request) {
+    const cache = await caches.open(PAGE_CACHE);
+
+    try {
+        const response = await fetch(request);
+        if (response.ok) {
+            cache.put(request, response.clone());
+        }
+        return response;
+    } catch {
+        const cached = await cache.match(request);
+        if (cached) return cached;
+
+        // Last resort: serve cached home page
+        return cache.match('/');
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -4,7 +4,25 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}FoolDog - Lëtzebuergesche Witzhünn{% endblock %}</title>
+
+        {# PWA — manifest & icons #}
+        <link rel="manifest" href="/manifest.json">
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>🐶</text></svg>">
+        <link rel="apple-touch-icon" href="/icons/icon-192.svg">
+
+        {# PWA — theme & appearance #}
+        <meta name="theme-color" content="#1a1a2e" media="(prefers-color-scheme: dark)">
+        <meta name="theme-color" content="#e8e0f0" media="(prefers-color-scheme: light)">
+        <meta name="application-name" content="FoolDog">
+        <meta name="description" content="Lëtzebuergesch Witze mat Ärem léifsten Witzhünn">
+
+        {# PWA — iOS Safari #}
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="apple-mobile-web-app-title" content="FoolDog">
+
+        {# PWA — Microsoft tiles #}
+        <meta name="msapplication-TileColor" content="#1a1a2e">
         <script>
             (function() {
                 var theme = localStorage.getItem('fooldog-theme') || 'dark';

--- a/templates/joke/index.html.twig
+++ b/templates/joke/index.html.twig
@@ -11,7 +11,22 @@
     aria-label="Thema wiesselen">
 </button>
 
-<div class="app-wrapper" {{ stimulus_controller('joke') }}>
+<div class="app-wrapper" {{ stimulus_controller('joke') }} {{ stimulus_controller('pwa') }}>
+
+    {# --- Offline Banner --- #}
+    <div class="offline-banner" {{ stimulus_target('pwa', 'offlineBanner') }} hidden>
+        🐾 Dir sidd offline — Witzen aus dem Cache
+    </div>
+
+    {# --- PWA Install Button --- #}
+    <button class="pwa-install-btn"
+        {{ stimulus_target('pwa', 'installBtn') }}
+        {{ stimulus_action('pwa', 'install') }}
+        hidden
+        title="FoolDog installéieren"
+        aria-label="FoolDog als App installéieren">
+        📲 App installéieren
+    </button>
 
     {# --- Background Paws --- #}
     <div class="bg-paw">🐾</div>


### PR DESCRIPTION
- Add Web App Manifest (public/manifest.json) with Luxembourgish metadata,
  theme colours, and SVG icons for 192×192 and 512×512 sizes
- Create Service Worker (public/sw.js) implementing:
  - Cache-first for Webpack build assets (content-hashed, safe to cache)
  - Network-first with offline fallback for API endpoints (/api/*)
  - Network-first with cached-page fallback for HTML navigation
  - Offline stub joke so the carousel works without a connection
- Add Stimulus pwa_controller.js handling the beforeinstallprompt event
  (shows/hides native install button) and online/offline status banner
- Register the Service Worker in assets/app.js on window load
- Add PWA meta tags to base.html.twig: manifest link, theme-color (adapts
  to dark/light preference), apple-mobile-web-app-* tags, description
- Add CSS for .offline-banner and .pwa-install-btn matching the existing
  glassmorphism design language
- Add offline banner and install button to the main joke page template

https://claude.ai/code/session_01PyJR38e8zzBBtrDLxqmkwE