### PR TITLE
feat: add share function for WhatsApp and Instagram Story

### DIFF
--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -129,8 +129,11 @@ export default class extends Controller {
             : 'linear-gradient(180deg, #1a1a2e 0%, #16213e 100%)';
 
         // Hannergrond mat Cards
-        const padding = '60px';
-        const cardMaxWidth = aspectRatio ? '720px' : '640px';
+        const padding = aspectRatio ? '80px' : '60px';
+        const cardMaxWidth = aspectRatio ? '800px' : '640px';
+        const emojiSize = aspectRatio ? '72px' : '56px';
+        const textSize = aspectRatio ? '32px' : '26px';
+        const lineHeight = aspectRatio ? '1.8' : '1.7';
 
         tempContainer.innerHTML = `
             <div style="
@@ -168,17 +171,20 @@ export default class extends Controller {
                     background: ${isLightTheme ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.05)'};
                     border: 3px solid ${isLightTheme ? 'rgba(184,134,11,0.4)' : 'rgba(245,200,66,0.3)'};
                     border-radius: 32px;
-                    padding: 60px 50px;
+                    padding: ${padding} 40px;
                     max-width: ${cardMaxWidth};
                     width: 100%;
                     text-align: center;
                     box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+                    word-wrap: break-word;
+                    overflow-wrap: break-word;
                 ">
-                    <div style="font-size: 60px; margin-bottom: 24px;">${this.jokeEmojiValue || '🐾'}</div>
+                    <div style="font-size: ${emojiSize}; margin-bottom: 20px; line-height: 1;">${this.jokeEmojiValue || '🐾'}</div>
                     <div style="
-                        font-size: 28px;
-                        line-height: 1.6;
+                        font-size: ${textSize};
+                        line-height: ${lineHeight};
                         color: ${isLightTheme ? '#1a1a2e' : '#ffffff'};
+                        max-width: 100%;
                     ">${this._escapeHtml(this.jokeTextValue)}</div>
                 </div>
 

--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -29,8 +29,11 @@ export default class extends Controller {
 
         if (this.isGenerating) return;
 
-        // Überpréifen ob e Witz ugewisen ass
-        const jokeText = this.jokeTextValue;
+        // Aktuell Witz-Daten aus dem DOM huelen
+        const jokeText = this._getCurrentJokeText();
+        const jokeEmoji = this._getCurrentJokeEmoji();
+
+        // Iwwerpréiwen ob e Witz ugewise ass
         if (!jokeText || jokeText.trim() === '') {
             this._showToast(`Weis fir d'éischt de Witz un!`, 'error');
             return;
@@ -40,10 +43,10 @@ export default class extends Controller {
         this._showLoadingState();
 
         try {
-            const dataUrl = await this._generateImage();
+            const dataUrl = await this._generateImage(jokeText, jokeEmoji);
             this._showPreview(dataUrl);
         } catch (error) {
-            console.error('Bildgeneratiounfeel:', error);
+            console.error('Bildgeneratiounsfehl:', error);
             this._showToast('Konnt Bild net generéieren. Probéier erëm!', 'error');
         } finally {
             this.isGenerating = false;
@@ -52,19 +55,22 @@ export default class extends Controller {
     }
 
     /**
-     * Deeelt den Witz via WhatsApp (Web Share API oder Fallback)
+     * Deealt den Witz via WhatsApp (Web Share API oder Fallback)
      */
     async shareToWhatsApp(): Promise<void> {
         try {
-            const dataUrl = await this._generateImage();
+            const jokeText = this._getCurrentJokeText();
+            const jokeEmoji = this._getCurrentJokeEmoji();
+            
+            const dataUrl = await this._generateImage(jokeText, jokeEmoji);
             const blob = await this._dataUrlToBlob(dataUrl);
             const file = new File([blob], 'fooldog-witz.png', { type: 'image/png' });
 
-            // Web Share API (funktionnéiert op mobilen Apparaten)
+            // Web Share API (funktionéiert op mobilen Apparaten)
             if (navigator.share && navigator.canShare?.({ files: [file] })) {
                 await navigator.share({
                     title: 'FoolDog - Lëtzebuergesche Witz',
-                    text: this._getShareText(),
+                    text: this._getShareText(jokeText, jokeEmoji),
                     files: [file]
                 });
                 this._closePreview();
@@ -75,19 +81,19 @@ export default class extends Controller {
             const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
             if (isMobile) {
-                // iOS/Android: Web Share API sollt funktionnéieren
+                // iOS/Android: Web Share API sollt funktionéieren
                 this._downloadImage(dataUrl, 'fooldog-whatsapp.png');
                 this._showToast('Bild erofgelueden. Deel et op WhatsApp!', 'success');
             } else {
                 // Desktop: WhatsApp Web Link
-                const shareUrl = `https://web.whatsapp.com/send?text=${encodeURIComponent(this._getShareText() + '\n\nhttps://fooldog.lu')}`;
+                const shareUrl = `https://web.whatsapp.com/send?text=${encodeURIComponent(this._getShareText(jokeText, jokeEmoji) + '\n\nhttps://fooldog.lu')}`;
                 this._downloadImage(dataUrl, 'fooldog-whatsapp.png');
                 window.open(shareUrl, '_blank', 'noopener,noreferrer');
             }
 
             this._closePreview();
         } catch (error) {
-            console.error('WhatsApp Share Feel:', error);
+            console.error('WhatsApp Share Fehl:', error);
             this._showToast('Konnt net deelen. Probéier erëm!', 'error');
         }
     }
@@ -97,22 +103,52 @@ export default class extends Controller {
      */
     async downloadForInstagram(): Promise<void> {
         try {
-            const dataUrl = await this._generateImage(9 / 16);
+            const jokeText = this._getCurrentJokeText();
+            const jokeEmoji = this._getCurrentJokeEmoji();
+            
+            const dataUrl = await this._generateImage(jokeText, jokeEmoji, 9 / 16);
             const timestamp = new Date().getTime();
             this._downloadImage(dataUrl, `fooldog-story-${timestamp}.png`);
             this._showToast('Bild fir Instagram Story bereet! 📸', 'success');
             this._closePreview();
         } catch (error) {
-            console.error('Instagram Download Feel:', error);
+            console.error('Instagram Download Fehl:', error);
             this._showToast('Konnt Bild net eroflueden. Probéier erëm!', 'error');
         }
     }
 
     /**
+     * Huet de aktuell Witz-Text aus dem DOM
+     */
+    private _getCurrentJokeText(): string {
+        // Sich no dem visible joke text an der card
+        const textElement = this.cardTarget.querySelector('.joke-text') as HTMLElement;
+        if (textElement && textElement.style.display !== 'none' && textElement.textContent) {
+            return textElement.textContent.trim();
+        }
+        
+        // Fallback: Stimulus Value
+        return this.jokeTextValue || '';
+    }
+
+    /**
+     * Huet de aktuell Witz-Emoji aus dem DOM
+     */
+    private _getCurrentJokeEmoji(): string {
+        // Sich no dem joke-emoji an der card
+        const emojiElement = this.cardTarget.querySelector('.joke-emoji') as HTMLElement;
+        if (emojiElement && emojiElement.textContent) {
+            return emojiElement.textContent.trim();
+        }
+        
+        // Fallback: Stimulus Value
+        return this.jokeEmojiValue || '🐾';
+    }
+
+    /**
      * Generéiert d'Bild aus der Joke-Card
      */
-    private async _generateImage(aspectRatio?: number): Promise<string> {
-        const card = this.cardTarget;
+    private async _generateImage(jokeText: string, jokeEmoji: string, aspectRatio?: number): Promise<string> {
         const isLightTheme = document.documentElement.getAttribute('data-theme') === 'light';
 
         // Temporäre Container fir d'Bildgeneratioun
@@ -179,13 +215,13 @@ export default class extends Controller {
                     word-wrap: break-word;
                     overflow-wrap: break-word;
                 ">
-                    <div style="font-size: ${emojiSize}; margin-bottom: 20px; line-height: 1;">${this.jokeEmojiValue || '🐾'}</div>
+                    <div style="font-size: ${emojiSize}; margin-bottom: 20px; line-height: 1;">${jokeEmoji || '🐾'}</div>
                     <div style="
                         font-size: ${textSize};
                         line-height: ${lineHeight};
                         color: ${isLightTheme ? '#1a1a2e' : '#ffffff'};
                         max-width: 100%;
-                    ">${this._escapeHtml(this.jokeTextValue)}</div>
+                    ">${this._escapeHtml(jokeText)}</div>
                 </div>
 
                 <!-- Footer -->
@@ -278,9 +314,9 @@ export default class extends Controller {
     /**
      * Gëtt de Share Text zeréck
      */
-    private _getShareText(): string {
-        const emoji = this.jokeEmojiValue || '🐶';
-        return `${emoji} ${this.jokeTextValue}\n\n🐾 Deel mat FoolDog!`;
+    private _getShareText(jokeText: string, jokeEmoji: string): string {
+        const emoji = jokeEmoji || '🐶';
+        return `${emoji} ${jokeText}\n\n🐾 Deel mat FoolDog!`;
     }
 
     /**

--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -2,13 +2,12 @@ import { Controller } from '@hotwired/stimulus';
 import * as htmlToImage from 'html-to-image';
 
 export default class extends Controller {
-    static targets = ['card', 'previewModal', 'previewImage', 'shareCanvas'];
+    static targets = ['previewModal', 'previewImage', 'shareCanvas'];
     static values = {
         jokeText: String,
         jokeEmoji: String
     };
 
-    declare readonly cardTarget: HTMLElement;
     declare readonly previewModalTarget: HTMLElement;
     declare readonly previewImageTarget: HTMLImageElement;
     declare readonly shareCanvasTarget: HTMLElement;
@@ -121,8 +120,12 @@ export default class extends Controller {
      * Huet de aktuell Witz-Text aus dem DOM
      */
     private _getCurrentJokeText(): string {
+        // Sich no der joke-card (ausserhalb vum share controller)
+        const card = document.querySelector('.joke-card');
+        if (!card) return this.jokeTextValue || '';
+        
         // Sich no dem visible joke text an der card
-        const textElement = this.cardTarget.querySelector('.joke-text') as HTMLElement;
+        const textElement = card.querySelector('.joke-text') as HTMLElement;
         if (textElement && textElement.style.display !== 'none' && textElement.textContent) {
             return textElement.textContent.trim();
         }
@@ -135,8 +138,12 @@ export default class extends Controller {
      * Huet de aktuell Witz-Emoji aus dem DOM
      */
     private _getCurrentJokeEmoji(): string {
+        // Sich no der joke-card (ausserhalb vum share controller)
+        const card = document.querySelector('.joke-card');
+        if (!card) return this.jokeEmojiValue || '🐾';
+        
         // Sich no dem joke-emoji an der card
-        const emojiElement = this.cardTarget.querySelector('.joke-emoji') as HTMLElement;
+        const emojiElement = card.querySelector('.joke-emoji') as HTMLElement;
         if (emojiElement && emojiElement.textContent) {
             return emojiElement.textContent.trim();
         }

--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -32,7 +32,7 @@ export default class extends Controller {
         // Überpréifen ob e Witz ugewisen ass
         const jokeText = this.jokeTextValue;
         if (!jokeText || jokeText.trim() === '') {
-            this._showToast('Weis fir d'" éischt de Witz un!', 'error');
+            this._showToast('Weis fir d'éischt de Witz un!', 'error');
             return;
         }
 

--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -265,8 +265,11 @@ export default class extends Controller {
      * Weist d'Bild-Virschau am Modal un
      */
     private _showPreview(dataUrl: string): void {
-        this.previewImageTarget.src = dataUrl;
-        this.previewModalTarget.classList.add('share-modal--visible');
+        const previewImage = document.querySelector('[data-share-target="previewImage"]') as HTMLImageElement;
+        const previewModal = document.querySelector('[data-share-target="previewModal"]') as HTMLElement;
+        
+        if (previewImage) previewImage.src = dataUrl;
+        if (previewModal) previewModal.classList.add('share-modal--visible');
         document.body.style.overflow = 'hidden';
     }
 
@@ -278,9 +281,12 @@ export default class extends Controller {
     }
 
     private _closePreview(): void {
-        this.previewModalTarget.classList.remove('share-modal--visible');
+        const previewModal = document.querySelector('[data-share-target="previewModal"]') as HTMLElement;
+        const previewImage = document.querySelector('[data-share-target="previewImage"]') as HTMLImageElement;
+        
+        if (previewModal) previewModal.classList.remove('share-modal--visible');
         document.body.style.overflow = '';
-        this.previewImageTarget.src = '';
+        if (previewImage) previewImage.src = '';
     }
 
     /**

--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -32,7 +32,7 @@ export default class extends Controller {
         // Überpréifen ob e Witz ugewisen ass
         const jokeText = this.jokeTextValue;
         if (!jokeText || jokeText.trim() === '') {
-            this._showToast('Weis fir d'éischt de Witz un!', 'error');
+            this._showToast(`Weis fir d'éischt de Witz un!`, 'error');
             return;
         }
 

--- a/assets/controllers/share_controller.ts
+++ b/assets/controllers/share_controller.ts
@@ -1,0 +1,325 @@
+import { Controller } from '@hotwired/stimulus';
+import * as htmlToImage from 'html-to-image';
+
+export default class extends Controller {
+    static targets = ['card', 'previewModal', 'previewImage', 'shareCanvas'];
+    static values = {
+        jokeText: String,
+        jokeEmoji: String
+    };
+
+    declare readonly cardTarget: HTMLElement;
+    declare readonly previewModalTarget: HTMLElement;
+    declare readonly previewImageTarget: HTMLImageElement;
+    declare readonly shareCanvasTarget: HTMLElement;
+    declare jokeTextValue: string;
+    declare jokeEmojiValue: string;
+
+    private isGenerating: boolean = false;
+
+    connect(): void {
+        this.isGenerating = false;
+    }
+
+    /**
+     * Generéiert e Bild aus der Joke-Card mat html-to-image
+     */
+    async share(event: Event): Promise<void> {
+        event.preventDefault();
+
+        if (this.isGenerating) return;
+
+        // Überpréifen ob e Witz ugewisen ass
+        const jokeText = this.jokeTextValue;
+        if (!jokeText || jokeText.trim() === '') {
+            this._showToast('Weis fir d'" éischt de Witz un!', 'error');
+            return;
+        }
+
+        this.isGenerating = true;
+        this._showLoadingState();
+
+        try {
+            const dataUrl = await this._generateImage();
+            this._showPreview(dataUrl);
+        } catch (error) {
+            console.error('Bildgeneratiounfeel:', error);
+            this._showToast('Konnt Bild net generéieren. Probéier erëm!', 'error');
+        } finally {
+            this.isGenerating = false;
+            this._hideLoadingState();
+        }
+    }
+
+    /**
+     * Deeelt den Witz via WhatsApp (Web Share API oder Fallback)
+     */
+    async shareToWhatsApp(): Promise<void> {
+        try {
+            const dataUrl = await this._generateImage();
+            const blob = await this._dataUrlToBlob(dataUrl);
+            const file = new File([blob], 'fooldog-witz.png', { type: 'image/png' });
+
+            // Web Share API (funktionnéiert op mobilen Apparaten)
+            if (navigator.share && navigator.canShare?.({ files: [file] })) {
+                await navigator.share({
+                    title: 'FoolDog - Lëtzebuergesche Witz',
+                    text: this._getShareText(),
+                    files: [file]
+                });
+                this._closePreview();
+                return;
+            }
+
+            // Fallback: WhatsApp Web mat Text + Bild Download
+            const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
+            if (isMobile) {
+                // iOS/Android: Web Share API sollt funktionnéieren
+                this._downloadImage(dataUrl, 'fooldog-whatsapp.png');
+                this._showToast('Bild erofgelueden. Deel et op WhatsApp!', 'success');
+            } else {
+                // Desktop: WhatsApp Web Link
+                const shareUrl = `https://web.whatsapp.com/send?text=${encodeURIComponent(this._getShareText() + '\n\nhttps://fooldog.lu')}`;
+                this._downloadImage(dataUrl, 'fooldog-whatsapp.png');
+                window.open(shareUrl, '_blank', 'noopener,noreferrer');
+            }
+
+            this._closePreview();
+        } catch (error) {
+            console.error('WhatsApp Share Feel:', error);
+            this._showToast('Konnt net deelen. Probéier erëm!', 'error');
+        }
+    }
+
+    /**
+     * Lued d'Bild fir Instagram Story erof (9:16 Format)
+     */
+    async downloadForInstagram(): Promise<void> {
+        try {
+            const dataUrl = await this._generateImage(9 / 16);
+            const timestamp = new Date().getTime();
+            this._downloadImage(dataUrl, `fooldog-story-${timestamp}.png`);
+            this._showToast('Bild fir Instagram Story bereet! 📸', 'success');
+            this._closePreview();
+        } catch (error) {
+            console.error('Instagram Download Feel:', error);
+            this._showToast('Konnt Bild net eroflueden. Probéier erëm!', 'error');
+        }
+    }
+
+    /**
+     * Generéiert d'Bild aus der Joke-Card
+     */
+    private async _generateImage(aspectRatio?: number): Promise<string> {
+        const card = this.cardTarget;
+        const isLightTheme = document.documentElement.getAttribute('data-theme') === 'light';
+
+        // Temporäre Container fir d'Bildgeneratioun
+        const tempContainer = document.createElement('div');
+        tempContainer.style.position = 'fixed';
+        tempContainer.style.left = '-9999px';
+        tempContainer.style.top = '-9999px';
+        tempContainer.style.width = aspectRatio ? '1080px' : '800px';
+        tempContainer.style.zIndex = '-1';
+
+        // Theme-aware Background
+        const bgGradient = isLightTheme
+            ? 'linear-gradient(180deg, #e8e0f0 0%, #d4ccdf 100%)'
+            : 'linear-gradient(180deg, #1a1a2e 0%, #16213e 100%)';
+
+        // Hannergrond mat Cards
+        const padding = '60px';
+        const cardMaxWidth = aspectRatio ? '720px' : '640px';
+
+        tempContainer.innerHTML = `
+            <div style="
+                width: ${aspectRatio ? '1080px' : '800px'};
+                height: ${aspectRatio ? '1920px' : 'auto'};
+                min-height: ${aspectRatio ? '1920px' : '600px'};
+                background: ${bgGradient};
+                padding: ${padding};
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                box-sizing: border-box;
+                font-family: Georgia, serif;
+            ">
+                <!-- Logo / Header -->
+                <div style="
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    margin-bottom: 40px;
+                ">
+                    <div style="font-size: 80px; margin-bottom: 10px;">🐶</div>
+                    <div style="
+                        font-size: 36px;
+                        font-weight: bold;
+                        font-style: italic;
+                        color: ${isLightTheme ? '#b8860b' : '#f5c842'};
+                        letter-spacing: 0.1em;
+                    ">FoolDog</div>
+                </div>
+
+                <!-- Joke Card -->
+                <div style="
+                    background: ${isLightTheme ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.05)'};
+                    border: 3px solid ${isLightTheme ? 'rgba(184,134,11,0.4)' : 'rgba(245,200,66,0.3)'};
+                    border-radius: 32px;
+                    padding: 60px 50px;
+                    max-width: ${cardMaxWidth};
+                    width: 100%;
+                    text-align: center;
+                    box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+                ">
+                    <div style="font-size: 60px; margin-bottom: 24px;">${this.jokeEmojiValue || '🐾'}</div>
+                    <div style="
+                        font-size: 28px;
+                        line-height: 1.6;
+                        color: ${isLightTheme ? '#1a1a2e' : '#ffffff'};
+                    ">${this._escapeHtml(this.jokeTextValue)}</div>
+                </div>
+
+                <!-- Footer -->
+                <div style="
+                    margin-top: 50px;
+                    font-size: 20px;
+                    color: ${isLightTheme ? '#4a5568' : '#a0b4d6'};
+                    letter-spacing: 0.1em;
+                    text-transform: uppercase;
+                ">
+                    fooldog.lu
+                </div>
+            </div>
+        `;
+
+        document.body.appendChild(tempContainer);
+
+        try {
+            const targetElement = tempContainer.firstElementChild as HTMLElement;
+
+            const dataUrl = await htmlToImage.toPng(targetElement, {
+                pixelRatio: 3, // Hoich Qualitéit fir Retina/Instagram
+                quality: 1,
+                backgroundColor: isLightTheme ? '#e8e0f0' : '#1a1a2e'
+            });
+
+            return dataUrl;
+        } finally {
+            document.body.removeChild(tempContainer);
+        }
+    }
+
+    /**
+     * Weist d'Bild-Virschau am Modal un
+     */
+    private _showPreview(dataUrl: string): void {
+        this.previewImageTarget.src = dataUrl;
+        this.previewModalTarget.classList.add('share-modal--visible');
+        document.body.style.overflow = 'hidden';
+    }
+
+    /**
+     * Schléisst d'Preview Modal
+     */
+    closePreview(): void {
+        this._closePreview();
+    }
+
+    private _closePreview(): void {
+        this.previewModalTarget.classList.remove('share-modal--visible');
+        document.body.style.overflow = '';
+        this.previewImageTarget.src = '';
+    }
+
+    /**
+     * Lued d'Bild erof
+     */
+    private _downloadImage(dataUrl: string, filename: string): void {
+        const link = document.createElement('a');
+        link.download = filename;
+        link.href = dataUrl;
+        link.click();
+    }
+
+    /**
+     * Konvertéiert Data URL zu Blob
+     */
+    private _dataUrlToBlob(dataUrl: string): Blob {
+        const byteString = atob(dataUrl.split(',')[1]);
+        const mimeString = dataUrl.split(',')[0].split(':')[1].split(';')[0];
+        const ab = new ArrayBuffer(byteString.length);
+        const ia = new Uint8Array(ab);
+
+        for (let i = 0; i < byteString.length; i++) {
+            ia[i] = byteString.charCodeAt(i);
+        }
+
+        return new Blob([ab], { type: mimeString });
+    }
+
+    /**
+     * Eloagert HTML anerkannt Zeechen
+     */
+    private _escapeHtml(text: string): string {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    /**
+     * Gëtt de Share Text zeréck
+     */
+    private _getShareText(): string {
+        const emoji = this.jokeEmojiValue || '🐶';
+        return `${emoji} ${this.jokeTextValue}\n\n🐾 Deel mat FoolDog!`;
+    }
+
+    /**
+     * Loading State weisen
+     */
+    private _showLoadingState(): void {
+        const event = new CustomEvent('share:loading', { detail: { loading: true } });
+        this.element.dispatchEvent(event);
+    }
+
+    private _hideLoadingState(): void {
+        const event = new CustomEvent('share:loading', { detail: { loading: false } });
+        this.element.dispatchEvent(event);
+    }
+
+    /**
+     * Toast Notification weisen
+     */
+    private _showToast(message: string, type: 'success' | 'error' = 'success'): void {
+        // Benotzt den existéierenden Toast System wann et ewell gëtt
+        // Fallback: Einfachen Toast erstellen
+        const toast = document.createElement('div');
+        toast.className = `share-toast share-toast--${type}`;
+        toast.textContent = message;
+        toast.style.cssText = `
+            position: fixed;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: ${type === 'success' ? 'rgba(74, 222, 128, 0.95)' : 'rgba(248, 113, 113, 0.95)'};
+            color: #1a1a2e;
+            padding: 16px 28px;
+            border-radius: 50px;
+            font-size: 15px;
+            font-weight: 600;
+            z-index: 10000;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+            animation: slideUp 0.3s ease;
+        `;
+
+        document.body.appendChild(toast);
+
+        setTimeout(() => {
+            toast.style.animation = 'slideDown 0.3s ease forwards';
+            setTimeout(() => toast.remove(), 300);
+        }, 3000);
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -376,6 +376,352 @@ html.no-transition *::after {
 }
 
 /* ===========================
+   Share Feature
+   =========================== */
+
+/* --- Share Actions (Initial Buttons) --- */
+.share-actions {
+    display: flex;
+    justify-content: center;
+    margin-top: 24px;
+}
+
+.btn-share {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--color-gold-btn-bg);
+    border: 2px solid var(--color-gold-border-btn);
+    border-radius: 50px;
+    color: var(--color-gold);
+    padding: 14px 32px;
+    font-size: 1rem;
+    font-family: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: 0.03em;
+    transition: all var(--transition-fast);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.btn-share:hover {
+    background: var(--color-gold-btn-hover);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 20px var(--color-gold-glow);
+}
+
+.btn-share:active {
+    transform: translateY(0);
+}
+
+.btn-share__icon {
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+.btn-share__text {
+    line-height: 1;
+}
+
+/* --- Share Modal --- */
+.share-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.share-modal--visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+.share-modal__content {
+    position: relative;
+    background: var(--color-card-bg);
+    border: 2px solid var(--color-card-border);
+    border-radius: 24px;
+    padding: 32px;
+    max-width: 480px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 25px 80px rgba(0, 0, 0, 0.6);
+    transform: scale(0.9) translateY(20px);
+    transition: transform 0.3s ease;
+}
+
+.share-modal--visible .share-modal__content {
+    transform: scale(1) translateY(0);
+}
+
+.share-modal__close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-github-bg);
+    border: 1px solid var(--color-github-border);
+    border-radius: 50%;
+    color: var(--color-text-secondary);
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.share-modal__close:hover {
+    background: var(--color-github-hover);
+    border-color: var(--color-github-border-hover);
+    color: var(--color-text);
+    transform: rotate(90deg);
+}
+
+.share-modal__title {
+    color: var(--color-gold);
+    font-size: 1.4rem;
+    font-weight: 700;
+    text-align: center;
+    margin: 0 0 24px 0;
+    padding-right: 40px;
+    font-style: italic;
+}
+
+.share-modal__preview {
+    background: var(--color-bg-start);
+    border-radius: 16px;
+    padding: 16px;
+    margin-bottom: 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+}
+
+.share-modal__preview img {
+    max-width: 100%;
+    max-height: 400px;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    object-fit: contain;
+}
+
+.share-modal__actions {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+/* --- Share Modal Buttons --- */
+.btn-share-modal {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 14px 24px;
+    border-radius: 50px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    border: 2px solid transparent;
+    transition: all var(--transition-fast);
+    letter-spacing: 0.02em;
+    flex: 1;
+    min-width: 140px;
+    justify-content: center;
+}
+
+.btn-share-modal__icon {
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+.btn-share-modal--whatsapp {
+    background: rgba(74, 222, 128, 0.15);
+    border-color: rgba(74, 222, 128, 0.4);
+    color: #4ade80;
+}
+
+[data-theme="light"] .btn-share-modal--whatsapp {
+    background: rgba(22, 163, 74, 0.1);
+    border-color: rgba(22, 163, 74, 0.3);
+    color: #16a34a;
+}
+
+.btn-share-modal--whatsapp:hover {
+    background: rgba(74, 222, 128, 0.25);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(74, 222, 128, 0.3);
+}
+
+.btn-share-modal--instagram {
+    background: linear-gradient(135deg, rgba(225, 48, 108, 0.15) 0%, rgba(193, 53, 132, 0.15) 50%, rgba(245, 96, 64, 0.15) 100%);
+    border-color: rgba(225, 48, 108, 0.4);
+    color: #f56040;
+}
+
+[data-theme="light"] .btn-share-modal--instagram {
+    background: linear-gradient(135deg, rgba(225, 48, 108, 0.1) 0%, rgba(193, 53, 132, 0.1) 50%, rgba(245, 96, 64, 0.1) 100%);
+    border-color: rgba(225, 48, 108, 0.3);
+    color: #e1306c;
+}
+
+.btn-share-modal--instagram:hover {
+    background: linear-gradient(135deg, rgba(225, 48, 108, 0.25) 0%, rgba(193, 53, 132, 0.25) 50%, rgba(245, 96, 64, 0.25) 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(225, 48, 108, 0.3);
+}
+
+/* --- Toast Notifications --- */
+.share-toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 16px 28px;
+    border-radius: 50px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    z-index: 10000;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    animation: slideUp 0.3s ease;
+    text-align: center;
+    max-width: 90vw;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.share-toast--success {
+    background: rgba(74, 222, 128, 0.95);
+    color: #0f2818;
+}
+
+.share-toast--error {
+    background: rgba(248, 113, 113, 0.95);
+    color: #3f0f0f;
+}
+
+[data-theme="light"] .share-toast--success {
+    background: rgba(22, 163, 74, 0.95);
+    color: #ffffff;
+}
+
+[data-theme="light"] .share-toast--error {
+    background: rgba(220, 38, 38, 0.95);
+    color: #ffffff;
+}
+
+/* Toast Animations */
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(-50%) translateY(20px);
+    }
+}
+
+/* --- Share Feature Responsive --- */
+@media (max-width: 480px) {
+    .share-actions {
+        margin-top: 20px;
+    }
+
+    .btn-share {
+        padding: 12px 24px;
+        font-size: 0.95rem;
+    }
+
+    .share-modal {
+        padding: 12px;
+    }
+
+    .share-modal__content {
+        padding: 20px;
+        border-radius: 20px;
+    }
+
+    .share-modal__close {
+        top: 12px;
+        right: 12px;
+        width: 36px;
+        height: 36px;
+        font-size: 1.1rem;
+    }
+
+    .share-modal__title {
+        font-size: 1.2rem;
+        margin-bottom: 16px;
+    }
+
+    .share-modal__preview {
+        padding: 12px;
+        margin-bottom: 16px;
+        min-height: 150px;
+    }
+
+    .share-modal__preview img {
+        max-height: 280px;
+    }
+
+    .share-modal__actions {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .btn-share-modal {
+        width: 100%;
+        padding: 12px 20px;
+        font-size: 0.9rem;
+    }
+
+    .share-toast {
+        padding: 14px 20px;
+        font-size: 0.9rem;
+        bottom: 16px;
+    }
+}
+
+@media (max-width: 360px) {
+    .share-modal__content {
+        padding: 16px;
+    }
+
+    .share-modal__preview img {
+        max-height: 220px;
+    }
+}
+
+/* ===========================
    Responsive
    =========================== */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
             "license": "UNLICENSED",
             "dependencies": {
                 "@hotwired/stimulus": "^3.2.2",
-                "@symfony/stimulus-bridge": "^4.0.1"
+                "@symfony/stimulus-bridge": "^4.0.1",
+                "html-to-image": "^1.11.13"
             },
             "devDependencies": {
                 "@babel/core": "^7.17.0",
@@ -4806,6 +4807,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/html-to-image": {
+            "version": "1.11.13",
+            "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+            "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+            "license": "MIT"
         },
         "node_modules/htmlparser2": {
             "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "@hotwired/stimulus": "^3.2.2",
-        "@symfony/stimulus-bridge": "^4.0.1"
+        "@symfony/stimulus-bridge": "^4.0.1",
+        "html-to-image": "^1.11.13"
     }
 }

--- a/templates/joke/index.html.twig
+++ b/templates/joke/index.html.twig
@@ -68,6 +68,53 @@
         </button>
     </div>
 
+    {# --- Share Buttons --- #}
+    <div class="share-actions"
+         {{ stimulus_controller('share') }}
+         {{ stimulus_target('share', 'shareCanvas') }}>
+
+        <button class="btn-share btn-share--whatsapp"
+                {{ stimulus_action('share', 'share') }}
+                title="Op WhatsApp deelen">
+            <span class="btn-share__icon">💬</span>
+            <span class="btn-share__text">Deelen</span>
+        </button>
+    </div>
+
+    {# --- Share Preview Modal --- #}
+    <div class="share-modal"
+         {{ stimulus_target('share', 'previewModal') }}
+         {{ stimulus_action('share', 'closePreview', 'click') }}>
+
+        <div class="share-modal__content" {{ stimulus_action('share', 'stopPropagation', 'click') }}>
+            <button class="share-modal__close"
+                    {{ stimulus_action('share', 'closePreview') }}
+                    aria-label="Zoumaachen">
+                ✕
+            </button>
+
+            <h3 class="share-modal__title">Deel dëse Witz! 🐶</h3>
+
+            <div class="share-modal__preview">
+                <img {{ stimulus_target('share', 'previewImage') }} alt="Witz Preview">
+            </div>
+
+            <div class="share-modal__actions">
+                <button class="btn-share-modal btn-share-modal--whatsapp"
+                        {{ stimulus_action('share', 'shareToWhatsApp') }}>
+                    <span class="btn-share-modal__icon">💬</span>
+                    WhatsApp
+                </button>
+
+                <button class="btn-share-modal btn-share-modal--instagram"
+                        {{ stimulus_action('share', 'downloadForInstagram') }}>
+                    <span class="btn-share-modal__icon">📸</span>
+                    Instagram Story
+                </button>
+            </div>
+        </div>
+    </div>
+
     {# --- Footer Links --- #}
     <div class="footer-links">
         <a href="https://github.com/Mukaarts/FoolDog"


### PR DESCRIPTION
## What was done

Added share functionality for FoolDog jokes including WhatsApp sharing and Instagram Story image generation.

- New ShareController with html-to-image integration
- WhatsApp share button (mobile + desktop fallback)
- Instagram Story image generation with Glassmorphism design
- Share preview modal with download option
- Theme-aware background (dark/light mode)
- Mobile-first with Web Share API support

## Why

Closes #13

## How to test

1. Open a joke
2. Click "Deelen" button
3. Test WhatsApp share
4. Test Instagram Story download

## Blocker

None